### PR TITLE
Add unit tests for HashPassword function

### DIFF
--- a/app/src/HashPassword.test.ts
+++ b/app/src/HashPassword.test.ts
@@ -1,0 +1,34 @@
+import { hashPassword } from './HashPassword';
+
+describe('hashPassword', () => {
+  test('should hash a simple password correctly', async () => {
+    const hash = await hashPassword('password123');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64); // SHA-256 produces a 64-character hex string
+    expect(hash).toMatch(/^[0-9a-f]{64}$/); // Should be a valid hex string
+  });
+
+  test('should produce the same hash for the same input', async () => {
+    const hash1 = await hashPassword('testPassword');
+    const hash2 = await hashPassword('testPassword');
+    expect(hash1).toBe(hash2);
+  });
+
+  test('should produce different hashes for different inputs', async () => {
+    const hash1 = await hashPassword('password1');
+    const hash2 = await hashPassword('password2');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('should handle empty string', async () => {
+    const hash = await hashPassword('');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64);
+  });
+
+  test('should handle special characters', async () => {
+    const hash = await hashPassword('!@#$%^&*()_+{}[]|\\:;"\'<>,.?/');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64);
+  });
+}); 

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -3,3 +3,54 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock TextEncoder and crypto.subtle for tests
+class MockTextEncoder {
+  // Add the required property from the TextEncoder interface
+  encoding = 'utf-8';
+  
+  encode(input: string): Uint8Array {
+    const encoder = require('util').TextEncoder
+      ? new (require('util').TextEncoder)()
+      : {
+          encode: (str: string) => {
+            const buf = Buffer.from(str, 'utf-8');
+            return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+          }
+        };
+    
+    return encoder.encode(input);
+  }
+  
+  // Implement the required encodeInto method
+  encodeInto(source: string, destination: Uint8Array): { read: number; written: number } {
+    const buf = Buffer.from(source, 'utf-8');
+    const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const length = Math.min(bytes.length, destination.length);
+    
+    for (let i = 0; i < length; i++) {
+      destination[i] = bytes[i];
+    }
+    
+    return {
+      read: length,
+      written: length
+    };
+  }
+}
+
+// Mock crypto.subtle.digest
+const mockCrypto = {
+  subtle: {
+    digest: async (algorithm: string, data: ArrayBuffer): Promise<ArrayBuffer> => {
+      const crypto = require('crypto');
+      const hash = crypto.createHash(algorithm === 'SHA-256' ? 'sha256' : algorithm);
+      hash.update(new Uint8Array(data));
+      return Promise.resolve(new Uint8Array(hash.digest()).buffer);
+    }
+  }
+};
+
+// Assign mocks to global object - fix the TextEncoder assignment
+global.TextEncoder = MockTextEncoder as any;
+global.crypto = mockCrypto as unknown as Crypto;


### PR DESCRIPTION
This PR adds unit tests for the password hashing functionality and adds mocks for TextEncoder and crypto.subtle APIs in the test environment.