### PR TITLE
Add unit tests for derivePassword function

### DIFF
--- a/app/src/HashPassword.test.ts
+++ b/app/src/HashPassword.test.ts
@@ -1,0 +1,34 @@
+import { hashPassword } from './HashPassword';
+
+describe('hashPassword', () => {
+  test('should hash a simple password correctly', async () => {
+    const hash = await hashPassword('password123');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64); // SHA-256 produces a 64-character hex string
+    expect(hash).toMatch(/^[0-9a-f]{64}$/); // Should be a valid hex string
+  });
+
+  test('should produce the same hash for the same input', async () => {
+    const hash1 = await hashPassword('testPassword');
+    const hash2 = await hashPassword('testPassword');
+    expect(hash1).toBe(hash2);
+  });
+
+  test('should produce different hashes for different inputs', async () => {
+    const hash1 = await hashPassword('password1');
+    const hash2 = await hashPassword('password2');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test('should handle empty string', async () => {
+    const hash = await hashPassword('');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64);
+  });
+
+  test('should handle special characters', async () => {
+    const hash = await hashPassword('!@#$%^&*()_+{}[]|\\:;"\'<>,.?/');
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBe(64);
+  });
+}); 

--- a/app/src/HashPassword.test.ts
+++ b/app/src/HashPassword.test.ts
@@ -1,4 +1,4 @@
-import { hashPassword } from './HashPassword';
+import { hashPassword, derivePassword } from './HashPassword';
 
 describe('hashPassword', () => {
   test('should hash a simple password correctly', async () => {
@@ -30,5 +30,85 @@ describe('hashPassword', () => {
     const hash = await hashPassword('!@#$%^&*()_+{}[]|\\:;"\'<>,.?/');
     expect(typeof hash).toBe('string');
     expect(hash.length).toBe(64);
+  });
+});
+
+describe('derivePassword', () => {
+  test('should derive password consistently for the same inputs', async () => {
+    const password = 'MySecurePassword123';
+    const username = 'testUser';
+    
+    const derived1 = await derivePassword(password, username);
+    const derived2 = await derivePassword(password, username);
+    
+    expect(derived1).toBe(derived2);
+    expect(derived1).toMatch(/^pbkdf2\$\d+\$[0-9a-f]+$/);
+    
+    // Verify format: pbkdf2$iterations$hexdigest
+    const parts = derived1.split('$');
+    expect(parts.length).toBe(3);
+    expect(parts[0]).toBe('pbkdf2');
+    expect(Number(parts[1])).toBe(100000); // Default iterations
+    expect(parts[2].length).toBe(64); // 256 bits = 32 bytes = 64 hex chars
+  });
+  
+  test('should produce different results for different passwords', async () => {
+    const username = 'testUser';
+    const password1 = 'Password1';
+    const password2 = 'Password2';
+    
+    const derived1 = await derivePassword(password1, username);
+    const derived2 = await derivePassword(password2, username);
+    
+    expect(derived1).not.toBe(derived2);
+  });
+  
+  test('should produce different results for different usernames', async () => {
+    const password = 'SecurePassword';
+    const username1 = 'user1';
+    const username2 = 'user2';
+    
+    const derived1 = await derivePassword(password, username1);
+    const derived2 = await derivePassword(password, username2);
+    
+    expect(derived1).not.toBe(derived2);
+  });
+  
+  test('should be case-insensitive for username', async () => {
+    const password = 'SecurePassword';
+    const username1 = 'TestUser';
+    const username2 = 'testuser';
+    
+    const derived1 = await derivePassword(password, username1);
+    const derived2 = await derivePassword(password, username2);
+    
+    expect(derived1).toBe(derived2);
+  });
+  
+  test('should use custom iterations when provided', async () => {
+    const password = 'SecurePassword';
+    const username = 'testuser';
+    const customIterations = 50000; // Different from default 100,000
+    
+    const derived = await derivePassword(password, username, customIterations);
+    const parts = derived.split('$');
+    
+    expect(Number(parts[1])).toBe(customIterations);
+  });
+  
+  test('should handle special characters in password', async () => {
+    const password = '!@#$%^&*()_+{}[]|\\:;"\'<>,.?/';
+    const username = 'testuser';
+    
+    const derived = await derivePassword(password, username);
+    expect(derived).toMatch(/^pbkdf2\$\d+\$[0-9a-f]+$/);
+  });
+  
+  test('should handle special characters in username', async () => {
+    const password = 'SecurePassword';
+    const username = 'test.user@example.com';
+    
+    const derived = await derivePassword(password, username);
+    expect(derived).toMatch(/^pbkdf2\$\d+\$[0-9a-f]+$/);
   });
 }); 

--- a/app/src/HashPassword.ts
+++ b/app/src/HashPassword.ts
@@ -16,3 +16,37 @@ export async function hashPassword(password: string): Promise<string> {
 
     return hashHex; // e.g. "9b74c9897bac770ffc029102a200c5de..."
 }
+
+// Deterministic client-side PBKDF2-SHA256.
+//   final = "pbkdf2$<iterations>$<hex-digest>"
+export async function derivePassword(
+  password: string,
+  username: string,
+  iterations = 100_000
+): Promise<string> {
+  const enc = new TextEncoder();
+
+  // 1. Import the raw password as a CryptoKey
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"]
+  );
+
+  // 2. Derive 256-bit key with username-based salt
+  const salt = enc.encode(username.toLowerCase());
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations, hash: "SHA-256" },
+    baseKey,
+    256
+  );
+
+  // 3. Convert to hex
+  const hex = Array.from(new Uint8Array(bits))
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return `pbkdf2$${iterations}$${hex}`;
+}

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -39,7 +39,10 @@ class MockTextEncoder {
   }
 }
 
-// Mock crypto.subtle.digest
+// Store password data for proper mocking
+const cryptoKeyStorage = new WeakMap();
+
+// Mock crypto.subtle with all needed methods
 const mockCrypto = {
   subtle: {
     digest: async (algorithm: string, data: ArrayBuffer): Promise<ArrayBuffer> => {
@@ -47,6 +50,61 @@ const mockCrypto = {
       const hash = crypto.createHash(algorithm === 'SHA-256' ? 'sha256' : algorithm);
       hash.update(new Uint8Array(data));
       return Promise.resolve(new Uint8Array(hash.digest()).buffer);
+    },
+    
+    // For derivePassword: Mock importKey
+    importKey: async (
+      format: string,
+      keyData: ArrayBuffer,
+      algorithm: any,
+      extractable: boolean,
+      keyUsages: string[]
+    ): Promise<CryptoKey> => {
+      // Create a mock key object
+      const mockKey = { 
+        type: 'secret', 
+        algorithm, 
+        extractable, 
+        usages: keyUsages 
+      } as CryptoKey;
+      
+      // Store the actual key data with our mock key
+      cryptoKeyStorage.set(mockKey, new Uint8Array(keyData));
+      
+      return mockKey;
+    },
+    
+    // For derivePassword: Mock deriveBits using Node's crypto PBKDF2
+    deriveBits: async (
+      algorithm: any,
+      baseKey: CryptoKey,
+      length: number
+    ): Promise<ArrayBuffer> => {
+      const crypto = require('crypto');
+      
+      // Get parameters from algorithm object
+      const { salt, iterations, hash } = algorithm;
+      const hashAlgo = hash === 'SHA-256' ? 'sha256' : hash;
+      
+      // Get the actual key data stored with our mock key
+      const keyData = cryptoKeyStorage.get(baseKey);
+      if (!keyData) {
+        throw new Error("Key data not found");
+      }
+      
+      // Convert key data to string for PBKDF2
+      const keyString = Buffer.from(keyData).toString();
+      
+      // Use Node's PBKDF2 implementation
+      const derivedKey = crypto.pbkdf2Sync(
+        keyString, 
+        salt, 
+        iterations, 
+        length / 8, // Convert bits to bytes
+        hashAlgo
+      );
+      
+      return Promise.resolve(derivedKey.buffer);
     }
   }
 };

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -3,3 +3,54 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock TextEncoder and crypto.subtle for tests
+class MockTextEncoder {
+  // Add the required property from the TextEncoder interface
+  encoding = 'utf-8';
+  
+  encode(input: string): Uint8Array {
+    const encoder = require('util').TextEncoder
+      ? new (require('util').TextEncoder)()
+      : {
+          encode: (str: string) => {
+            const buf = Buffer.from(str, 'utf-8');
+            return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+          }
+        };
+    
+    return encoder.encode(input);
+  }
+  
+  // Implement the required encodeInto method
+  encodeInto(source: string, destination: Uint8Array): { read: number; written: number } {
+    const buf = Buffer.from(source, 'utf-8');
+    const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const length = Math.min(bytes.length, destination.length);
+    
+    for (let i = 0; i < length; i++) {
+      destination[i] = bytes[i];
+    }
+    
+    return {
+      read: length,
+      written: length
+    };
+  }
+}
+
+// Mock crypto.subtle.digest
+const mockCrypto = {
+  subtle: {
+    digest: async (algorithm: string, data: ArrayBuffer): Promise<ArrayBuffer> => {
+      const crypto = require('crypto');
+      const hash = crypto.createHash(algorithm === 'SHA-256' ? 'sha256' : algorithm);
+      hash.update(new Uint8Array(data));
+      return Promise.resolve(new Uint8Array(hash.digest()).buffer);
+    }
+  }
+};
+
+// Assign mocks to global object - fix the TextEncoder assignment
+global.TextEncoder = MockTextEncoder as any;
+global.crypto = mockCrypto as unknown as Crypto;


### PR DESCRIPTION
This PR adds comprehensive unit tests for the derivePassword function and fixes the crypto mocks in setupTests.ts to properly handle password derivation tests.