### PR TITLE
Migrate to PBKDF2 password derivation

### DIFF
--- a/app/src/HashPassword.test.ts
+++ b/app/src/HashPassword.test.ts
@@ -1,37 +1,4 @@
-import { hashPassword, derivePassword } from './HashPassword';
-
-describe('hashPassword', () => {
-  test('should hash a simple password correctly', async () => {
-    const hash = await hashPassword('password123');
-    expect(typeof hash).toBe('string');
-    expect(hash.length).toBe(64); // SHA-256 produces a 64-character hex string
-    expect(hash).toMatch(/^[0-9a-f]{64}$/); // Should be a valid hex string
-  });
-
-  test('should produce the same hash for the same input', async () => {
-    const hash1 = await hashPassword('testPassword');
-    const hash2 = await hashPassword('testPassword');
-    expect(hash1).toBe(hash2);
-  });
-
-  test('should produce different hashes for different inputs', async () => {
-    const hash1 = await hashPassword('password1');
-    const hash2 = await hashPassword('password2');
-    expect(hash1).not.toBe(hash2);
-  });
-
-  test('should handle empty string', async () => {
-    const hash = await hashPassword('');
-    expect(typeof hash).toBe('string');
-    expect(hash.length).toBe(64);
-  });
-
-  test('should handle special characters', async () => {
-    const hash = await hashPassword('!@#$%^&*()_+{}[]|\\:;"\'<>,.?/');
-    expect(typeof hash).toBe('string');
-    expect(hash.length).toBe(64);
-  });
-});
+import { derivePassword } from './HashPassword';
 
 describe('derivePassword', () => {
   test('should derive password consistently for the same inputs', async () => {

--- a/app/src/HashPassword.ts
+++ b/app/src/HashPassword.ts
@@ -1,22 +1,3 @@
-export async function hashPassword(password: string): Promise<string> {
-    // Convert the string to a Uint8Array
-    const encoder = new TextEncoder();
-    const data = encoder.encode(password);
-
-    // Use SubtleCrypto to digest the data
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-
-    // Convert the hash buffer to a byte array
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-
-    // Convert bytes to hex string
-    const hashHex = hashArray
-        .map((byte) => byte.toString(16).padStart(2, '0'))
-        .join('');
-
-    return hashHex; // e.g. "9b74c9897bac770ffc029102a200c5de..."
-}
-
 // Deterministic client-side PBKDF2-SHA256.
 //   final = "pbkdf2$<iterations>$<hex-digest>"
 export async function derivePassword(


### PR DESCRIPTION
This PR migrates the application to use PBKDF2 for password derivation, providing improved security over the previous password hashing method. The implementation uses username-based salting for better protection against rainbow table attacks.