### PR TITLE
Fix auto-play comment

### DIFF
--- a/app/src/TrainingPageControl.tsx
+++ b/app/src/TrainingPageControl.tsx
@@ -102,7 +102,7 @@ const TrainingPageControl: React.FC<TrainingPageControlProps> = ({ variants, onC
         let interval: NodeJS.Timeout | null = null;
 
         if (autoLoadNext) {
-            // We auto-play in 1 second if there were errors, otherwise in 5 seconds
+            // We auto-play in 5 seconds if there were errors, otherwise in 1 second
             let durationMilliseconds = logic.hadErrors() ? 5000 : 1000;
 
             // We also give extra time per annotation


### PR DESCRIPTION
## Summary
- fix swapped timing in TrainingPageControl auto-play comment

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845305758ac8326b3b5a72cf33a3f05