### PR TITLE
Introduce moveScores map and update serialization

### DIFF
--- a/app/src/DataAccessLayer.test.ts
+++ b/app/src/DataAccessLayer.test.ts
@@ -29,6 +29,7 @@ describe.skip("DataAccessLayer - Main E2E Test", () => {
         // 3. Retrieve variants (should be empty or default)
         // ----------------------------------------------------------------------------
         let repertoireData = await dal.retrieveRepertoireData();
+        repertoireData.moveScores = {};
         // We can do some basic validation. For example, ensure the structure is correct.
         // The exact checks depend on your backend’s default initialization.
         expect(repertoireData).toBeDefined();
@@ -45,6 +46,7 @@ describe.skip("DataAccessLayer - Main E2E Test", () => {
                 numberOfTimesPlayed: 0,
                 lastSucceededEpoch: 0,
                 successEMA: 0,
+                moveScores: {}
             }
         ];
 
@@ -94,6 +96,7 @@ describe.skip("DataAccessLayer - Main E2E Test", () => {
                 numberOfTimesPlayed: 0,
                 lastSucceededEpoch: 0,
                 successEMA: 0,
+                moveScores: {}
             }
         ];
         updatedData.data = newVariants2;

--- a/app/src/RepertoireData.ts
+++ b/app/src/RepertoireData.ts
@@ -6,6 +6,7 @@ export interface OpeningVariantData {
     numberOfTimesPlayed: number;
     lastSucceededEpoch: number;
     successEMA: number;
+    moveScores: { [key: string]: number };
 }
 
 export interface RepertoireData {
@@ -13,4 +14,5 @@ export interface RepertoireData {
     currentEpoch: number;
     lastPlayedDate: Date;
     dailyPlayCount: number; // How many times user has played on the current date
+    moveScores: { [key: string]: number };
 }

--- a/app/src/RepertoireDataUtils.test.ts
+++ b/app/src/RepertoireDataUtils.test.ts
@@ -25,7 +25,7 @@ describe('RepertoireDataUtils', () => {
     describe('normalize', () => {
         it('should not add any variants', () => {
             // Prepare
-            const repertoireData: Partial<RepertoireData> = {};
+            const repertoireData: Partial<RepertoireData> = {} as RepertoireData;
 
             // Act
             RepertoireDataUtils.normalize(repertoireData as RepertoireData);
@@ -33,6 +33,8 @@ describe('RepertoireDataUtils', () => {
             // Assert
             expect(repertoireData.data).toBeDefined();
             expect(repertoireData.data).toHaveLength(0);
+            expect(repertoireData.moveScores).toBeDefined();
+            expect(Object.keys(repertoireData.moveScores!)).toHaveLength(0);
         });
 
         it('should set default fields if they are missing', () => {
@@ -41,7 +43,7 @@ describe('RepertoireDataUtils', () => {
                 data: [
                     { pgn: '1. e4 e5', orientation: 'white' } as unknown as OpeningVariantData
                 ]
-            };
+            } as RepertoireData;
 
             // Act
             RepertoireDataUtils.normalize(repertoireData as RepertoireData);
@@ -57,6 +59,7 @@ describe('RepertoireDataUtils', () => {
             expect(repertoireData.data![0].orientation).toBe('white');
             expect(repertoireData.currentEpoch).toBe(1);
             expect(repertoireData.lastPlayedDate?.toISOString()).toBe('2025-01-23T00:00:00.000Z');
+            expect(repertoireData.moveScores).toBeDefined();
         });
 
         it('should increment epoch and adjust success EMA if current date > lastPlayedDate (next day)', () => {
@@ -78,7 +81,8 @@ describe('RepertoireDataUtils', () => {
                 ],
                 currentEpoch: 5,
                 lastPlayedDate: yesterday,
-                dailyPlayCount: 5 // pretend we've played 5 times "yesterday"
+                dailyPlayCount: 5, // pretend we've played 5 times "yesterday"
+                moveScores: {}
             };
 
             // Act
@@ -116,7 +120,8 @@ describe('RepertoireDataUtils', () => {
                 ],
                 currentEpoch: 5,
                 lastPlayedDate: RepertoireDataUtils.getCurrentDateOnly(),
-                dailyPlayCount: 5
+                dailyPlayCount: 5,
+                moveScores: {}
             };
 
             // Act
@@ -162,7 +167,8 @@ describe('RepertoireDataUtils', () => {
                 ],
                 currentEpoch: 10,
                 lastPlayedDate: new Date(),
-                dailyPlayCount: 0
+                dailyPlayCount: 0,
+                moveScores: {}
             };
 
             // Act
@@ -212,7 +218,7 @@ describe('RepertoireDataUtils', () => {
             variants[1].currentEpoch = 9; // bigger than first
 
             // Act
-            const result = RepertoireDataUtils.convertToRepertoireData(variants, 3);
+            const result = RepertoireDataUtils.convertToRepertoireData(variants, 3, {});
 
             // Assert
             expect(result.data).toHaveLength(2);
@@ -233,6 +239,7 @@ describe('RepertoireDataUtils', () => {
             // currentEpoch should be the max among the variants
             expect(result.currentEpoch).toBe(9);
             expect(result.dailyPlayCount).toBe(3);
+            expect(result.moveScores).toEqual({});
 
             // lastPlayedDate should be "today"
             const today = RepertoireDataUtils.getCurrentDateOnly();

--- a/app/src/RepertoireDataUtils.ts
+++ b/app/src/RepertoireDataUtils.ts
@@ -21,6 +21,9 @@ export class RepertoireDataUtils {
         if (!repertoireData.dailyPlayCount) {
             repertoireData.dailyPlayCount = 0;
         }
+        if (!repertoireData.moveScores) {
+            repertoireData.moveScores = {};
+        }
 
         // Normalize the data
         for (const variant of repertoireData.data) {
@@ -77,7 +80,7 @@ export class RepertoireDataUtils {
         return variants;
     }
 
-    public static convertToRepertoireData(variants: OpeningVariant[], dailyPlayCount: number): RepertoireData {
+    public static convertToRepertoireData(variants: OpeningVariant[], dailyPlayCount: number, moveScores: { [key: string]: number }): RepertoireData {
         const data: OpeningVariantData[] = variants.map(variant => ({
             pgn: variant.pgn,
             orientation: variant.orientation,
@@ -92,7 +95,8 @@ export class RepertoireDataUtils {
             data,
             currentEpoch: Math.max(...variants.map(v => v.currentEpoch)),
             lastPlayedDate: RepertoireDataUtils.getCurrentDateOnly(),
-            dailyPlayCount: dailyPlayCount
+            dailyPlayCount: dailyPlayCount,
+            moveScores
         };
     }
 

--- a/app/src/TrainingPage.tsx
+++ b/app/src/TrainingPage.tsx
@@ -101,7 +101,7 @@ const TrainingPage: React.FC = () => {
         }
 
         try {
-            const newData = RepertoireDataUtils.convertToRepertoireData(orientationAndVariants.allVariants, repertoireData!.dailyPlayCount + 1);
+            const newData = RepertoireDataUtils.convertToRepertoireData(orientationAndVariants.allVariants, repertoireData!.dailyPlayCount + 1, repertoireData!.moveScores);
             setRepertoireData(newData); // Updating local copy - it will be used for loading the next round.
             await dal.storeRepertoireData(newData);
 


### PR DESCRIPTION
## Summary
- extend `OpeningVariantData` and `RepertoireData` with a `moveScores` map
- keep `moveScores` when normalising data
- include `moveScores` when converting to `RepertoireData`
- update training page and tests for new parameter
- adjust test fixtures

## Testing
- `yarn --cwd app install` *(fails: tunneling socket could not be established)*
- `yarn --cwd app test --watchAll=false` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68462da6d43083269a52fda6e616a536