### PR TITLE
Reset fullmove clock in FEN normalization

### DIFF
--- a/app/src/FenUtils.ts
+++ b/app/src/FenUtils.ts
@@ -1,14 +1,25 @@
 import { Chess } from 'chess.js';
 
 export function normalizeFenResetHalfmoveClock(fen: string): string {
+    const parts = fen.split(' ');
+    
     // We use FEN as a key. And in order to be able to jump from one variant to another, we need to reset halfmove clock.
     // This clock is used to determine if a draw can be claimed by the fifty-move rule. Since this app focuses on openings - it is not relevant.
     // Example:
     // 1. e4 c5 2. Nf3 e6  3. d4 cxd4 4. Nxd4 Nc6 => r1bqkbnr/pp1p1ppp/2n1p3/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5
     // 1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 e6  => r1bqkbnr/pp1p1ppp/2n1p3/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 0 5
     // Reset halfmove clock so transpositions match despite 50-move counter differences.
-    const parts = fen.split(' ');
     parts[4] = "0"; // parts[4] is the halfmove clock field
+
+    // We also use FEN to find a position. Another variance - we can reach the same position using different move order resulting in different number of moves.
+    // Example:
+    // 1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8. Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. c3
+    //      => r1bqk2r/5ppp/p1np1b2/1p1Np3/4P3/N1P5/PP3PPP/R2QKB1R b KQkq - 0 11
+    // 1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e6 6. Ndb5 d6 7. Bf4 e5 8. Bg5 a6 9. Na3 b5 10. Nd5 Be7 11. Bxf6 Bxf6 12. c3
+    //      => r1bqk2r/5ppp/p1np1b2/1p1Np3/4P3/N1P5/PP3PPP/R2QKB1R b KQkq - 0 12
+    // Reset fullmove clock so it would be possible to find both variants using either FEN
+    parts[5] = "1"; // parts[5] is the fullmove clock field
+
     return parts.join(' ');
 }
 

--- a/app/src/LaunchpadLogic.test.ts
+++ b/app/src/LaunchpadLogic.test.ts
@@ -25,7 +25,7 @@ describe('LaunchpadLogic - FEN to Variant Map', () => {
         expect(firstPosition![0].pgn).toBe('1. e4 e5 2. Nf3 Nc6 3. Bb5 a6');
 
         // Check the last position (copied from Lichess)
-        const lastPosition = fenMap.get('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4');
+        const lastPosition = fenMap.get('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1');
         expect(lastPosition).toBeDefined();
         expect(lastPosition!.length).toBe(1);
         expect(lastPosition![0].pgn).toBe('1. e4 e5 2. Nf3 Nc6 3. Bb5 a6');
@@ -41,7 +41,7 @@ describe('LaunchpadLogic - FEN to Variant Map', () => {
         const fenMap = (logic as any).fenToVariantMap as Map<string, OpeningVariant[]>;
 
         // PGN after 1. e4 e5 2. Nf3 Nc6 3. Bb5 should return two variants. Note that halfmove clock is reset to 0.
-        const position = fenMap.get('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 0 3');
+        const position = fenMap.get('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 0 1');
         expect(position).toBeDefined();
         expect(position!.length).toBe(2);
         expect(position![0].pgn).toBe(ruyLopezMorphyVariant.pgn);
@@ -58,7 +58,7 @@ describe('LaunchpadLogic - FEN to Variant Map', () => {
         const fenMap = (logic as any).fenToVariantMap as Map<string, OpeningVariant[]>;
 
         // PGN after 1. e4 e5 2. Nf3 Nc6 3. Bb5 should return two variants. Note that halfmove clock is reset to 0.
-        const position = fenMap.get('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 0 3');
+        const position = fenMap.get('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 0 1');
         expect(position).toBeDefined();
         expect(position!.length).toBe(2);
         expect(position![0].pgn).toBe(ruyLopezMorphyVariant.pgn);
@@ -75,7 +75,7 @@ describe('LaunchpadLogic - FEN to Variant Map', () => {
         const fenMap = (logic as any).fenToVariantMap as Map<string, OpeningVariant[]>;
 
         // PGN after 1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 should return two variants
-        const position = fenMap.get('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4');
+        const position = fenMap.get('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1');
         expect(position).toBeDefined();
         expect(position!.length).toBe(1);
         expect(position![0].pgn).toBe(ruyLopezMorphyVariant.pgn);
@@ -107,7 +107,7 @@ describe('LaunchpadLogic - Get Next Move', () => {
         const ruyLopezVariant: OpeningVariant = createOpeningVariant('1. e4 e5 2. Nf3 Nc6 3. Bb5 a6');
 
         // Above position (copied from Lichess.org)
-        const fen = 'r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4';
+        const fen = 'r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1';
 
         const logic = new LaunchpadLogic([ruyLopezVariant]);
 


### PR DESCRIPTION
    // We also use FEN to find a position. Another variance - we can reach the same position using different move order resulting in different number of moves.
    // Example:
    // 1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8. Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. c3
    //      => r1bqk2r/5ppp/p1np1b2/1p1Np3/4P3/N1P5/PP3PPP/R2QKB1R b KQkq - 0 11
    // 1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e6 6. Ndb5 d6 7. Bf4 e5 8. Bg5 a6 9. Na3 b5 10. Nd5 Be7 11. Bxf6 Bxf6 12. c3
    //      => r1bqk2r/5ppp/p1np1b2/1p1Np3/4P3/N1P5/PP3PPP/R2QKB1R b KQkq - 0 12
    // Reset fullmove clock so it would be possible to find both variants using either FEN
