### PR TITLE
Reduce annotation delay growth factor from 1.35 to 1.26

### DIFF
--- a/app/src/TrainingPageControl.tsx
+++ b/app/src/TrainingPageControl.tsx
@@ -53,7 +53,7 @@ const TABLE_FULL = 2;
 const TrainingPageControl: React.FC<TrainingPageControlProps> = ({ variants, fsrsCards, onCompletion, onLoadNext, orientation }) => {
 
     const ANNOTATION_DELAY_BASE_IN_MS = 200;
-    const ANNOTATION_DELAY_GROWTH = 1.35;
+    const ANNOTATION_DELAY_GROWTH = 1.26;
     const AUTOPLAY_MOVE_DELAY_MS = 250;
     const NORMAL_MOVE_DELAY_MS = 750;
 


### PR DESCRIPTION
The geometric growth factor for annotation arrow delays was causing excessive pauses for positions with many arrows (e.g. 11 arrows added ~15s). Reducing the growth from 1.35 to 1.26 caps 11 arrows at ~9s while keeping the single-arrow delay at 200ms.