### PR TITLE
Add mobile responsive CSS for Settings page and Header

### DIFF
--- a/app/src/Header.css
+++ b/app/src/Header.css
@@ -98,3 +98,38 @@
 .login-button:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .header {
+    flex-wrap: wrap;
+    padding: 0.3rem 0.5rem;
+  }
+
+  .header-title {
+    font-size: 16px;
+    margin-left: 0.25rem;
+  }
+
+  .header-nav {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+    margin: 0.25rem 0 0 0;
+    gap: 1.5rem;
+  }
+
+  .header-right {
+    min-width: 0;
+  }
+
+  .username-text {
+    display: inline-block;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 16px;
+    margin-right: 0.5rem;
+  }
+}

--- a/app/src/SettingsPage.css
+++ b/app/src/SettingsPage.css
@@ -1,6 +1,7 @@
 .settings-page {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   padding: 1.5rem;
 }
 
@@ -149,4 +150,45 @@
 .lichess-connect-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .settings-page {
+    padding: 0.75rem;
+  }
+
+  .settings-card {
+    padding: 1rem;
+  }
+
+  .settings-table th:nth-child(3),
+  .settings-table td:nth-child(3) {
+    display: none;
+  }
+
+  .settings-table th:nth-child(2),
+  .settings-table td:nth-child(2) {
+    width: auto;
+  }
+
+  .settings-actions {
+    flex-direction: column;
+  }
+
+  .settings-actions button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .lichess-status {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .lichess-connect-btn {
+    width: 100%;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
Add @media (max-width: 768px) breakpoints to SettingsPage.css and Header.css to fix layout overflow on mobile devices.

Settings page:
- Stack cards vertically with reduced padding
- Hide Description table column to fit narrow screens
- Make action buttons full-width and stacked
- Stack Lichess integration section vertically

Header:
- Wrap nav links to their own centered row
- Shrink title font size
- Truncate long usernames with ellipsis