### PR TITLE
Fix Lichess disconnect not persisting across page reload

### DIFF
--- a/app/src/LichessAuthService.ts
+++ b/app/src/LichessAuthService.ts
@@ -109,7 +109,8 @@ class LichessAuthServiceImpl {
             }
         }
 
-        // Reset the library's internal state
+        // Clear persisted token from localStorage and reset the library
+        this.oauth.reset();
         this.oauth = this.createOAuthClient();
     }
 


### PR DESCRIPTION
The logout() method cleared in-memory state but never called oauth.reset() to remove the token from localStorage. On reload, init() found and restored the stale token.

Add oauth.reset() before recreating the client to clear the persisted oauth2authcodepkce-state localStorage entry.