### PR TITLE
Add Paste PGN with subvariant arrow visualization

### DIFF
--- a/app/src/PgnImportUtils.test.ts
+++ b/app/src/PgnImportUtils.test.ts
@@ -1,0 +1,210 @@
+import { Chess } from 'chess.js';
+import { parsePgnWithVariations, tokenizePgn } from './PgnImportUtils';
+
+describe('PgnImportUtils', () => {
+    describe('tokenizePgn', () => {
+        it('tokenizes a simple PGN', () => {
+            const tokens = tokenizePgn('1. e4 e5 2. Nf3');
+            expect(tokens).toEqual(['1.', 'e4', 'e5', '2.', 'Nf3']);
+        });
+
+        it('tokenizes PGN with parenthesized variations', () => {
+            const tokens = tokenizePgn('1. e4 (1. d4 d5) 1... e5');
+            expect(tokens).toEqual([
+                '1.', 'e4', '(', '1.', 'd4', 'd5', ')', '1...', 'e5',
+            ]);
+        });
+
+        it('strips brace comments', () => {
+            const tokens = tokenizePgn('1. e4 {best move} e5');
+            expect(tokens).toEqual(['1.', 'e4', 'e5']);
+        });
+
+        it('strips NAGs', () => {
+            const tokens = tokenizePgn('1. e4 $1 e5 $2');
+            expect(tokens).toEqual(['1.', 'e4', 'e5']);
+        });
+
+        it('strips semicolon comments', () => {
+            const tokens = tokenizePgn('1. e4 e5 ; this is a comment\n2. Nf3');
+            expect(tokens).toEqual(['1.', 'e4', 'e5', '2.', 'Nf3']);
+        });
+    });
+
+    describe('parsePgnWithVariations', () => {
+        it('parses a simple PGN without variations', () => {
+            const result = parsePgnWithVariations('1. e4 e5 2. Nf3 Nc6');
+
+            const chess = new Chess();
+            chess.loadPgn('1. e4 e5 2. Nf3 Nc6');
+            expect(result.mainLinePgn).toBe(chess.pgn());
+            expect(result.subvariantArrows.size).toBe(0);
+        });
+
+        it('parses the user example PGN with one variation', () => {
+            const pgn =
+                '1. c4 Nf6 2. Nc3 g6 3. g3 Bg7 4. Bg2 O-O 5. e4 d6 6. Nge2 c5 ' +
+                '7. O-O Nc6 8. d3 Rb8 9. h3 a6 10. a4 Ne8 11. Be3 b5 12. cxb5 axb5 ' +
+                '13. axb5 (13. Nxb5 Nc7 14. Nxc7 Qxc7) 13... Nd4';
+
+            const result = parsePgnWithVariations(pgn);
+
+            // Main line should end with Nd4 and NOT contain Nxb5
+            expect(result.mainLinePgn).toContain('Nd4');
+            expect(result.mainLinePgn).not.toContain('Nxb5');
+
+            // Should have exactly one branch point
+            expect(result.subvariantArrows.size).toBe(1);
+
+            // Compute the branch FEN (after 12...axb5)
+            const chess = new Chess();
+            chess.loadPgn(
+                '1. c4 Nf6 2. Nc3 g6 3. g3 Bg7 4. Bg2 O-O 5. e4 d6 6. Nge2 c5 ' +
+                '7. O-O Nc6 8. d3 Rb8 9. h3 a6 10. a4 Ne8 11. Be3 b5 12. cxb5 axb5'
+            );
+            const branchFen = chess.fen();
+
+            const arrows = result.subvariantArrows.get(branchFen)!;
+            expect(arrows).toBeDefined();
+            expect(arrows).toHaveLength(4);
+
+            // Pair 1 (green): Nxb5 (c3→b5), Nc7 (e8→c7)
+            expect(arrows[0]).toEqual({ brush: 'G', orig: 'c3', dest: 'b5' });
+            expect(arrows[1]).toEqual({ brush: 'G', orig: 'e8', dest: 'c7' });
+
+            // Pair 2 (red): Nxc7 (b5→c7), Qxc7 (d8→c7)
+            expect(arrows[2]).toEqual({ brush: 'R', orig: 'b5', dest: 'c7' });
+            expect(arrows[3]).toEqual({ brush: 'R', orig: 'd8', dest: 'c7' });
+        });
+
+        it('ignores sub-sub-variants (depth >= 2)', () => {
+            const pgn = '1. e4 e5 (1... d5 (1... c5 2. Nf3) 2. exd5) 2. Nf3';
+            const result = parsePgnWithVariations(pgn);
+
+            expect(result.subvariantArrows.size).toBe(1);
+            const branchFen = new Chess('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1').fen();
+            const arrows = result.subvariantArrows.get(branchFen)!;
+            expect(arrows).toBeDefined();
+
+            // Only d5 and exd5 from the first-level variation (1...d5 2. exd5)
+            // 1...c5 2. Nf3 is depth 2, ignored
+            expect(arrows[0]).toEqual({ brush: 'G', orig: 'd7', dest: 'd5' });
+            expect(arrows[1]).toEqual({ brush: 'G', orig: 'e4', dest: 'd5' });
+        });
+
+        it('uses only the first variation per branch position', () => {
+            const pgn = '1. e4 (1. d4) (1. c4) 1... e5';
+            const result = parsePgnWithVariations(pgn);
+
+            expect(result.subvariantArrows.size).toBe(1);
+            const startFen = new Chess().fen();
+            const arrows = result.subvariantArrows.get(startFen)!;
+            expect(arrows).toBeDefined();
+            expect(arrows).toHaveLength(1);
+
+            // Should be d4, not c4
+            expect(arrows[0]).toEqual({ brush: 'G', orig: 'd2', dest: 'd4' });
+        });
+
+        it('handles variations at different positions', () => {
+            const pgn = '1. e4 (1. d4) 1... e5 (1... c5) 2. Nf3';
+            const result = parsePgnWithVariations(pgn);
+
+            expect(result.subvariantArrows.size).toBe(2);
+
+            // Variation after starting position: 1. d4
+            const startFen = new Chess().fen();
+            const arrows1 = result.subvariantArrows.get(startFen)!;
+            expect(arrows1).toHaveLength(1);
+            expect(arrows1[0]).toEqual({ brush: 'G', orig: 'd2', dest: 'd4' });
+
+            // Variation after 1. e4: 1...c5
+            const afterE4 = new Chess('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1').fen();
+            const arrows2 = result.subvariantArrows.get(afterE4)!;
+            expect(arrows2).toHaveLength(1);
+            expect(arrows2[0]).toEqual({ brush: 'G', orig: 'c7', dest: 'c5' });
+        });
+
+        it('caps arrows at 4 pairs (8 half-moves)', () => {
+            // A variation with more than 8 half-moves
+            const pgn = '1. e4 (1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3) 1... e5';
+            const result = parsePgnWithVariations(pgn);
+
+            const startFen = new Chess().fen();
+            const arrows = result.subvariantArrows.get(startFen)!;
+            // Max 8 half-moves = 4 pairs
+            expect(arrows).toHaveLength(8);
+
+            // Pair 1: green
+            expect(arrows[0].brush).toBe('G');
+            expect(arrows[1].brush).toBe('G');
+            // Pair 2: red
+            expect(arrows[2].brush).toBe('R');
+            expect(arrows[3].brush).toBe('R');
+            // Pair 3: blue
+            expect(arrows[4].brush).toBe('B');
+            expect(arrows[5].brush).toBe('B');
+            // Pair 4: yellow
+            expect(arrows[6].brush).toBe('Y');
+            expect(arrows[7].brush).toBe('Y');
+        });
+
+        it('strips PGN headers', () => {
+            const pgn = `[Event "Test"]
+[Site "?"]
+[Date "2024.01.01"]
+
+1. e4 e5 (1... d5) 2. Nf3`;
+            const result = parsePgnWithVariations(pgn);
+
+            expect(result.mainLinePgn).toContain('Nf3');
+            expect(result.subvariantArrows.size).toBe(1);
+        });
+
+        it('handles empty PGN', () => {
+            const result = parsePgnWithVariations('');
+            expect(result.mainLinePgn).toBe('');
+            expect(result.subvariantArrows.size).toBe(0);
+        });
+
+        it('handles PGN with result marker', () => {
+            const result = parsePgnWithVariations('1. e4 e5 1-0');
+            expect(result.mainLinePgn).toContain('e4');
+            expect(result.mainLinePgn).toContain('e5');
+        });
+
+        it('handles variation with a single move', () => {
+            const pgn = '1. e4 (1. d4) 1... e5';
+            const result = parsePgnWithVariations(pgn);
+
+            const startFen = new Chess().fen();
+            const arrows = result.subvariantArrows.get(startFen)!;
+            expect(arrows).toHaveLength(1);
+            expect(arrows[0]).toEqual({ brush: 'G', orig: 'd2', dest: 'd4' });
+        });
+
+        it('handles castling in variations', () => {
+            const pgn = '1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. d3 Be7 5. O-O (5. Bg5) 5... O-O';
+            const result = parsePgnWithVariations(pgn);
+
+            expect(result.subvariantArrows.size).toBe(1);
+            // The variation move is 5. Bg5
+            const arrows = [...result.subvariantArrows.values()][0];
+            expect(arrows).toHaveLength(1);
+            expect(arrows[0]).toEqual({ brush: 'G', orig: 'c1', dest: 'g5' });
+        });
+
+        it('handles unmatched closing parentheses gracefully', () => {
+            const pgn = '1. e4 e5) 2. Nf3';
+            const result = parsePgnWithVariations(pgn);
+            // Should not throw; parses what it can
+            expect(result.mainLinePgn).toContain('e4');
+        });
+
+        it('returns empty main line for completely invalid moves', () => {
+            const result = parsePgnWithVariations('1. Zz9 Qq0');
+            expect(result.mainLinePgn).toBe('');
+            expect(result.subvariantArrows.size).toBe(0);
+        });
+    });
+});

--- a/app/src/PgnImportUtils.ts
+++ b/app/src/PgnImportUtils.ts
@@ -1,0 +1,195 @@
+import { Chess } from 'chess.js';
+import { Annotation } from './Annotation';
+
+export interface ParsedPgn {
+    mainLinePgn: string;
+    subvariantArrows: Map<string, Annotation[]>;
+}
+
+// Arrow brush colors for each pair of half-moves in a subvariant:
+// Pair 1 (green)  = default right-click drag
+// Pair 2 (red)    = Ctrl + right-click drag
+// Pair 3 (blue)   = Alt + right-click drag
+// Pair 4 (yellow) = Shift+Alt + right-click drag
+const PAIR_BRUSHES: Annotation['brush'][] = ['G', 'R', 'B', 'Y'];
+
+function stripHeaders(pgnText: string): string {
+    return pgnText.replace(/^\s*\[[A-Za-z].*\]\s*$/gm, '').trim();
+}
+
+export function tokenizePgn(movetext: string): string[] {
+    const tokens: string[] = [];
+    let i = 0;
+
+    while (i < movetext.length) {
+        if (/\s/.test(movetext[i])) {
+            i++;
+            continue;
+        }
+
+        // Skip brace comments { ... }
+        if (movetext[i] === '{') {
+            let d = 1;
+            i++;
+            while (i < movetext.length && d > 0) {
+                if (movetext[i] === '{') d++;
+                if (movetext[i] === '}') d--;
+                i++;
+            }
+            continue;
+        }
+
+        // Skip semicolon comments (rest of line)
+        if (movetext[i] === ';') {
+            while (i < movetext.length && movetext[i] !== '\n') i++;
+            continue;
+        }
+
+        // Parentheses are structural tokens
+        if (movetext[i] === '(' || movetext[i] === ')') {
+            tokens.push(movetext[i]);
+            i++;
+            continue;
+        }
+
+        // Skip NAGs ($N)
+        if (movetext[i] === '$') {
+            i++;
+            while (i < movetext.length && /\d/.test(movetext[i])) i++;
+            continue;
+        }
+
+        // Read a word (move number or SAN move)
+        let word = '';
+        while (
+            i < movetext.length &&
+            !/\s/.test(movetext[i]) &&
+            movetext[i] !== '(' &&
+            movetext[i] !== ')' &&
+            movetext[i] !== '{' &&
+            movetext[i] !== ';'
+        ) {
+            word += movetext[i];
+            i++;
+        }
+
+        if (word) {
+            tokens.push(word);
+        }
+    }
+
+    return tokens;
+}
+
+function isMoveNumberOrResult(token: string): boolean {
+    return (
+        /^\d+\.+$/.test(token) ||
+        ['1-0', '0-1', '1/2-1/2', '*'].includes(token)
+    );
+}
+
+function variationMovesToArrows(
+    branchFen: string,
+    moves: string[]
+): Annotation[] {
+    const arrows: Annotation[] = [];
+    const chess = new Chess(branchFen);
+
+    const maxHalfMoves = Math.min(moves.length, PAIR_BRUSHES.length * 2);
+
+    for (let i = 0; i < maxHalfMoves; i++) {
+        const pairIndex = Math.floor(i / 2);
+        const brush = PAIR_BRUSHES[pairIndex];
+
+        try {
+            const moveResult = chess.move(moves[i]);
+            if (!moveResult) break;
+
+            arrows.push({
+                brush,
+                orig: moveResult.from,
+                dest: moveResult.to,
+            });
+        } catch {
+            break;
+        }
+    }
+
+    return arrows;
+}
+
+/**
+ * Parses a PGN string that may contain variations (parenthesized alternatives).
+ *
+ * Returns the main-line PGN (without variations) and a map of
+ * branch-point FEN → arrow annotations that visualize the first
+ * subvariant at each branch point.
+ *
+ * Sub-sub-variants (depth ≥ 2) are ignored.
+ * Only the first variation per branch position is used.
+ */
+export function parsePgnWithVariations(pgnText: string): ParsedPgn {
+    const movetext = stripHeaders(pgnText);
+    const tokens = tokenizePgn(movetext);
+
+    const chess = new Chess();
+    let depth = 0;
+    let previousFen = chess.fen();
+    const subvariantArrows = new Map<string, Annotation[]>();
+    let currentVariationMoves: string[] = [];
+    let currentVariationBranchFen = '';
+
+    for (const token of tokens) {
+        if (token === '(') {
+            if (depth === 0) {
+                currentVariationBranchFen = previousFen;
+                currentVariationMoves = [];
+            }
+            depth++;
+            continue;
+        }
+
+        if (token === ')') {
+            if (depth <= 0) {
+                // Unmatched closing paren — skip rather than going negative
+                continue;
+            }
+            if (depth === 1 && currentVariationMoves.length > 0) {
+                // Only use the first variation per branch position
+                if (!subvariantArrows.has(currentVariationBranchFen)) {
+                    const arrows = variationMovesToArrows(
+                        currentVariationBranchFen,
+                        currentVariationMoves
+                    );
+                    if (arrows.length > 0) {
+                        subvariantArrows.set(
+                            currentVariationBranchFen,
+                            arrows
+                        );
+                    }
+                }
+            }
+            depth--;
+            continue;
+        }
+
+        if (isMoveNumberOrResult(token)) continue;
+
+        if (depth === 0) {
+            previousFen = chess.fen();
+            try {
+                chess.move(token);
+            } catch {
+                break;
+            }
+        } else if (depth === 1) {
+            currentVariationMoves.push(token);
+        }
+        // depth >= 2: sub-sub-variants are ignored
+    }
+
+    return {
+        mainLinePgn: chess.pgn(),
+        subvariantArrows,
+    };
+}

--- a/app/src/VariantPage.css
+++ b/app/src/VariantPage.css
@@ -43,3 +43,68 @@
   border-radius: 5px; /* Rounded corners */
   min-height: 100px;
 }
+
+/* --- Paste PGN section --- */
+
+.paste-pgn-section {
+  width: 100%;
+  max-width: 704px;
+  margin-top: 0.5rem;
+}
+
+.paste-pgn-toggle {
+  cursor: pointer;
+  user-select: none;
+  font-weight: bold;
+  color: #333;
+  background: none;
+  border: none;
+  padding: 12px 8px;
+  font-size: inherit;
+  font-family: inherit;
+  min-height: 44px;
+}
+
+.paste-pgn-toggle:hover {
+  color: #0056b3;
+}
+
+.paste-pgn-content {
+  margin-top: 0.5rem;
+}
+
+.paste-pgn-content textarea {
+  width: 100%;
+  min-height: 100px;
+  font-family: monospace;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+  box-sizing: border-box;
+  font-size: 16px;
+}
+
+.paste-pgn-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.paste-pgn-actions button {
+  min-height: 44px;
+  padding: 8px 16px;
+}
+
+/* Screen-reader only helper */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/app/src/VariantPage.tsx
+++ b/app/src/VariantPage.tsx
@@ -6,6 +6,7 @@ import { Chess, Move } from 'chess.js';
 import { Annotation } from './Annotation';
 import { extractAnnotations, serializeAnnotationsAsComment } from './AnnotationUtils';
 import { DatabaseOpeningsUtils } from './DatabaseOpeningsUtils';
+import { parsePgnWithVariations } from './PgnImportUtils';
 import PgnControl from './PgnControl';
 import './VariantPage.css';
 
@@ -66,6 +67,8 @@ const VariantPage: React.FC = () => {
         y: 0,
         moveIndex: -1,
     });
+    const [showPastePgn, setShowPastePgn] = useState(false);
+    const [pastedPgnText, setPastedPgnText] = useState('');
 
     // On mount (or if initialPgn changes in edit mode), load the PGN into chess
     useEffect(() => {
@@ -143,6 +146,44 @@ const VariantPage: React.FC = () => {
 
     const handleFlipBoard = () => {
         setOrientation((o) => (o === 'white' ? 'black' : 'white'));
+    };
+
+    const handleLoadPgn = () => {
+        if (!pastedPgnText.trim()) {
+            return;
+        }
+
+        try {
+            const parsed = parsePgnWithVariations(pastedPgnText);
+
+            if (!parsed.mainLinePgn && pastedPgnText.trim().length > 0) {
+                alert('Could not parse any moves from the pasted PGN.');
+                return;
+            }
+
+            chess.reset();
+            if (parsed.mainLinePgn) {
+                chess.loadPgn(parsed.mainLinePgn);
+            }
+
+            // Convert subvariant arrows to annotations map
+            const newAnnotationsMap: { [fen: string]: Annotation[] } = {};
+            parsed.subvariantArrows.forEach((arrows, fen) => {
+                newAnnotationsMap[fen] = arrows;
+            });
+
+            setPgn(chess.pgn());
+            setAnnotationsMap(newAnnotationsMap);
+            // Explicitly set FEN to handle same-length PGN reloads
+            // where setMoveIndex would be a no-op.
+            setFen(chess.fen());
+            setMoveIndex(chess.history().length);
+            setPastedPgnText('');
+            setShowPastePgn(false);
+        } catch (ex: unknown) {
+            const message = ex instanceof Error ? ex.message : String(ex);
+            alert(`Failed to load PGN: ${message}`);
+        }
     };
 
     const handleSave = async (resetStats: boolean = false) => {
@@ -367,6 +408,36 @@ const VariantPage: React.FC = () => {
                         />
                     </div>
                 </div>
+            </div>
+
+            {/* Paste PGN section */}
+            <div className="paste-pgn-section">
+                <button
+                    className="paste-pgn-toggle"
+                    onClick={() => setShowPastePgn(prev => !prev)}
+                    aria-expanded={showPastePgn}
+                    aria-controls="paste-pgn-content"
+                >
+                    <span aria-hidden="true">{showPastePgn ? '▾' : '▸'}</span> Paste PGN
+                </button>
+                {showPastePgn && (
+                    <div className="paste-pgn-content" id="paste-pgn-content" role="region">
+                        <label htmlFor="paste-pgn-textarea" className="sr-only">
+                            PGN text with optional variations
+                        </label>
+                        <textarea
+                            id="paste-pgn-textarea"
+                            value={pastedPgnText}
+                            onChange={(e) => setPastedPgnText(e.target.value)}
+                            placeholder="Paste PGN here (variations in parentheses become arrows)…"
+                        />
+                        <div className="paste-pgn-actions">
+                            <button onClick={handleLoadPgn} disabled={!pastedPgnText.trim()}>
+                                Load
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
 
             {contextMenu.show && (


### PR DESCRIPTION
Add a collapsible 'Paste PGN' section to the variant editor that parses PGN with variations and converts first-level subvariants into colored arrows on the board (green, red, blue, yellow per pair of half-moves).

- New PgnImportUtils.ts parser with 18 tests
- Accessible UI with proper ARIA attrs and mobile-friendly touch targets
- Handles malformed PGN and same-length reload edge cases