### PR TITLE
Disable coordinates on Games page mini board

### DIFF
--- a/app/src/GamesPage.tsx
+++ b/app/src/GamesPage.tsx
@@ -153,6 +153,7 @@ const GameRow: React.FC<GameRowProps> = ({ game, annotation, username }) => {
                     fen={boardFen}
                     orientation={annotation?.miniBoardOrientation ?? meta.userColor ?? 'white'}
                     interactive={false}
+                    coordinates={false}
                     turnColor="white"
                     legalMoves={new Map()}
                     annotations={boardAnnotations}


### PR DESCRIPTION
Set coordinates={false} on the ChessBoard component to prevent coordinates from obscuring the small mini board on the Games page.